### PR TITLE
Clickable largeUI

### DIFF
--- a/cyinput/Form1.vb
+++ b/cyinput/Form1.vb
@@ -54,6 +54,14 @@ Public Class Form1
     'Temp files checking variables
     Dim tempFilelistOriginal As String()
     Dim temppath As String = IO.Path.GetTempPath.ToString & "cyinput\"
+    
+    Protected Overrides ReadOnly Property CreateParams As CreateParams
+        Get
+            Dim newParams = MyBase.CreateParams
+            newParams.ExStyle = newParams.ExStyle Or &H8000000  'WS_EX_NOACTIVATE
+            Return newParams
+        End Get
+    End Property
 
     Private Function appendToCharSet(number As String)
 
@@ -157,6 +165,14 @@ Public Class Form1
         handleNextWord()
 
         isSelecting = False
+    End Sub
+    
+    Public Sub SendAssoWord(wordtosend As String)
+        SendOut(wordtosend)
+        lastusedword = wordtosend
+        handleNextWord()
+        isSelecting = False
+        largeUI.updateUIbyCharCode(charset)
     End Sub
 
     Private Sub loadWords(Optional mode As Short = 0)
@@ -335,6 +351,15 @@ Public Class Form1
         Draw(largeUI.l7, filterStarToEmptyString(textArray(sp + 6)))
         Draw(largeUI.l8, filterStarToEmptyString(textArray(sp + 7)))
         Draw(largeUI.l9, filterStarToEmptyString(textArray(sp + 8)))
+        largeUI.s1.Text = filterStarToEmptyString(textArray(sp))
+        largeUI.s2.Text = filterStarToEmptyString(textArray(sp + 1))
+        largeUI.s3.Text = filterStarToEmptyString(textArray(sp + 2))
+        largeUI.s4.Text = filterStarToEmptyString(textArray(sp + 3))
+        largeUI.s5.Text = filterStarToEmptyString(textArray(sp + 4))
+        largeUI.s6.Text = filterStarToEmptyString(textArray(sp + 5))
+        largeUI.s7.Text = filterStarToEmptyString(textArray(sp + 6))
+        largeUI.s8.Text = filterStarToEmptyString(textArray(sp + 7))
+        largeUI.s9.Text = filterStarToEmptyString(textArray(sp + 8))
     End Sub
 
     Private Function filterStarToEmptyString(inString As String)
@@ -585,7 +610,7 @@ Public Class Form1
             Return Nothing
         End If
     End Function
-    Private Sub HandleHotkey(keycode As Integer)
+    Public Sub HandleHotkey(keycode As Integer)
         Select Case (keycode)
             Case 96
                 appendToCharSet(0)

--- a/cyinput/largeUI.Designer.vb
+++ b/cyinput/largeUI.Designer.vb
@@ -1,9 +1,9 @@
-﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
 Partial Class largeUI
     Inherits System.Windows.Forms.Form
 
     'Form overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -20,7 +20,7 @@ Partial Class largeUI
     'NOTE: The following procedure is required by the Windows Form Designer
     'It can be modified using the Windows Form Designer.  
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(largeUI))
         Me.PictureBox1 = New System.Windows.Forms.PictureBox()
@@ -36,6 +36,17 @@ Partial Class largeUI
         Me.l9 = New System.Windows.Forms.Label()
         Me.l8 = New System.Windows.Forms.Label()
         Me.l7 = New System.Windows.Forms.Label()
+        Me.l10 = New System.Windows.Forms.Label()
+        Me.l11 = New System.Windows.Forms.Label()
+        Me.s7 = New System.Windows.Forms.Label()
+        Me.s8 = New System.Windows.Forms.Label()
+        Me.s9 = New System.Windows.Forms.Label()
+        Me.s4 = New System.Windows.Forms.Label()
+        Me.s5 = New System.Windows.Forms.Label()
+        Me.s6 = New System.Windows.Forms.Label()
+        Me.s1 = New System.Windows.Forms.Label()
+        Me.s2 = New System.Windows.Forms.Label()
+        Me.s3 = New System.Windows.Forms.Label()
         CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).BeginInit()
         CType(Me.PictureBox2, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.Panel1.SuspendLayout()
@@ -94,6 +105,7 @@ Partial Class largeUI
         Me.l1.Name = "l1"
         Me.l1.Size = New System.Drawing.Size(43, 43)
         Me.l1.TabIndex = 3
+        Me.l1.Tag = "1"
         Me.l1.Text = "個"
         Me.l1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
@@ -105,6 +117,7 @@ Partial Class largeUI
         Me.l2.Name = "l2"
         Me.l2.Size = New System.Drawing.Size(43, 43)
         Me.l2.TabIndex = 4
+        Me.l2.Tag = "2"
         Me.l2.Text = "能"
         Me.l2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
@@ -116,6 +129,7 @@ Partial Class largeUI
         Me.l3.Name = "l3"
         Me.l3.Size = New System.Drawing.Size(43, 43)
         Me.l3.TabIndex = 5
+        Me.l3.Tag = "3"
         Me.l3.Text = "的"
         Me.l3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
@@ -127,6 +141,7 @@ Partial Class largeUI
         Me.l6.Name = "l6"
         Me.l6.Size = New System.Drawing.Size(43, 43)
         Me.l6.TabIndex = 8
+        Me.l6.Tag = "6"
         Me.l6.Text = "就"
         Me.l6.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
@@ -138,6 +153,7 @@ Partial Class largeUI
         Me.l5.Name = "l5"
         Me.l5.Size = New System.Drawing.Size(43, 43)
         Me.l5.TabIndex = 7
+        Me.l5.Tag = "5"
         Me.l5.Text = "資"
         Me.l5.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
@@ -149,6 +165,7 @@ Partial Class largeUI
         Me.l4.Name = "l4"
         Me.l4.Size = New System.Drawing.Size(43, 43)
         Me.l4.TabIndex = 6
+        Me.l4.Tag = "4"
         Me.l4.Text = "到"
         Me.l4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
@@ -160,6 +177,7 @@ Partial Class largeUI
         Me.l9.Name = "l9"
         Me.l9.Size = New System.Drawing.Size(43, 43)
         Me.l9.TabIndex = 11
+        Me.l9.Tag = "9"
         Me.l9.Text = "好"
         Me.l9.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
@@ -171,6 +189,7 @@ Partial Class largeUI
         Me.l8.Name = "l8"
         Me.l8.Size = New System.Drawing.Size(43, 43)
         Me.l8.TabIndex = 10
+        Me.l8.Tag = "8"
         Me.l8.Text = "這"
         Me.l8.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
@@ -182,8 +201,126 @@ Partial Class largeUI
         Me.l7.Name = "l7"
         Me.l7.Size = New System.Drawing.Size(43, 43)
         Me.l7.TabIndex = 9
+        Me.l7.Tag = "7"
         Me.l7.Text = "你"
         Me.l7.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        'l10
+        '
+        Me.l10.BackColor = System.Drawing.Color.Transparent
+        Me.l10.Location = New System.Drawing.Point(8, 181)
+        Me.l10.Name = "l10"
+        Me.l10.Size = New System.Drawing.Size(93, 43)
+        Me.l10.TabIndex = 12
+        Me.l10.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        'l11
+        '
+        Me.l11.BackColor = System.Drawing.Color.Transparent
+        Me.l11.Location = New System.Drawing.Point(109, 181)
+        Me.l11.Name = "l11"
+        Me.l11.Size = New System.Drawing.Size(43, 43)
+        Me.l11.TabIndex = 13
+        Me.l11.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        's7
+        '
+        Me.s7.BackColor = System.Drawing.Color.Transparent
+        Me.s7.Font = New System.Drawing.Font("細明體_HKSCS", 18.0!)
+        Me.s7.Location = New System.Drawing.Point(4, 27)
+        Me.s7.Name = "s7"
+        Me.s7.Size = New System.Drawing.Size(28, 28)
+        Me.s7.TabIndex = 14
+        Me.s7.Text = "你"
+        Me.s7.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        's8
+        '
+        Me.s8.BackColor = System.Drawing.Color.Transparent
+        Me.s8.Font = New System.Drawing.Font("細明體_HKSCS", 18.0!)
+        Me.s8.Location = New System.Drawing.Point(55, 27)
+        Me.s8.Name = "s8"
+        Me.s8.Size = New System.Drawing.Size(28, 28)
+        Me.s8.TabIndex = 15
+        Me.s8.Text = "你"
+        Me.s8.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        's9
+        '
+        Me.s9.BackColor = System.Drawing.Color.Transparent
+        Me.s9.Font = New System.Drawing.Font("細明體_HKSCS", 18.0!)
+        Me.s9.Location = New System.Drawing.Point(106, 27)
+        Me.s9.Name = "s9"
+        Me.s9.Size = New System.Drawing.Size(28, 28)
+        Me.s9.TabIndex = 16
+        Me.s9.Text = "你"
+        Me.s9.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        's4
+        '
+        Me.s4.BackColor = System.Drawing.Color.Transparent
+        Me.s4.Font = New System.Drawing.Font("細明體_HKSCS", 18.0!)
+        Me.s4.Location = New System.Drawing.Point(4, 76)
+        Me.s4.Name = "s4"
+        Me.s4.Size = New System.Drawing.Size(28, 28)
+        Me.s4.TabIndex = 17
+        Me.s4.Text = "你"
+        Me.s4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        's5
+        '
+        Me.s5.BackColor = System.Drawing.Color.Transparent
+        Me.s5.Font = New System.Drawing.Font("細明體_HKSCS", 18.0!)
+        Me.s5.Location = New System.Drawing.Point(55, 78)
+        Me.s5.Name = "s5"
+        Me.s5.Size = New System.Drawing.Size(28, 28)
+        Me.s5.TabIndex = 18
+        Me.s5.Text = "你"
+        Me.s5.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        's6
+        '
+        Me.s6.BackColor = System.Drawing.Color.Transparent
+        Me.s6.Font = New System.Drawing.Font("細明體_HKSCS", 18.0!)
+        Me.s6.Location = New System.Drawing.Point(106, 78)
+        Me.s6.Name = "s6"
+        Me.s6.Size = New System.Drawing.Size(28, 28)
+        Me.s6.TabIndex = 19
+        Me.s6.Text = "你"
+        Me.s6.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        's1
+        '
+        Me.s1.BackColor = System.Drawing.Color.Transparent
+        Me.s1.Font = New System.Drawing.Font("細明體_HKSCS", 18.0!)
+        Me.s1.Location = New System.Drawing.Point(4, 129)
+        Me.s1.Name = "s1"
+        Me.s1.Size = New System.Drawing.Size(28, 28)
+        Me.s1.TabIndex = 20
+        Me.s1.Text = "你"
+        Me.s1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        's2
+        '
+        Me.s2.BackColor = System.Drawing.Color.Transparent
+        Me.s2.Font = New System.Drawing.Font("細明體_HKSCS", 18.0!)
+        Me.s2.Location = New System.Drawing.Point(55, 129)
+        Me.s2.Name = "s2"
+        Me.s2.Size = New System.Drawing.Size(28, 28)
+        Me.s2.TabIndex = 21
+        Me.s2.Text = "你"
+        Me.s2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        's3
+        '
+        Me.s3.BackColor = System.Drawing.Color.Transparent
+        Me.s3.Font = New System.Drawing.Font("細明體_HKSCS", 18.0!)
+        Me.s3.Location = New System.Drawing.Point(106, 129)
+        Me.s3.Name = "s3"
+        Me.s3.Size = New System.Drawing.Size(28, 28)
+        Me.s3.TabIndex = 22
+        Me.s3.Text = "你"
+        Me.s3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
         'largeUI
         '
@@ -191,6 +328,17 @@ Partial Class largeUI
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
         Me.ClientSize = New System.Drawing.Size(170, 259)
+        Me.Controls.Add(Me.s3)
+        Me.Controls.Add(Me.s2)
+        Me.Controls.Add(Me.s1)
+        Me.Controls.Add(Me.s6)
+        Me.Controls.Add(Me.s5)
+        Me.Controls.Add(Me.s4)
+        Me.Controls.Add(Me.s9)
+        Me.Controls.Add(Me.s8)
+        Me.Controls.Add(Me.s7)
+        Me.Controls.Add(Me.l11)
+        Me.Controls.Add(Me.l10)
         Me.Controls.Add(Me.l9)
         Me.Controls.Add(Me.l8)
         Me.Controls.Add(Me.l7)
@@ -234,4 +382,15 @@ Partial Class largeUI
     Friend WithEvents l9 As Label
     Friend WithEvents l8 As Label
     Friend WithEvents l7 As Label
+    Friend WithEvents l10 As Label
+    Friend WithEvents l11 As Label
+    Friend WithEvents s7 As Label
+    Friend WithEvents s8 As Label
+    Friend WithEvents s9 As Label
+    Friend WithEvents s4 As Label
+    Friend WithEvents s5 As Label
+    Friend WithEvents s6 As Label
+    Friend WithEvents s1 As Label
+    Friend WithEvents s2 As Label
+    Friend WithEvents s3 As Label
 End Class

--- a/cyinput/largeUI.vb
+++ b/cyinput/largeUI.vb
@@ -1,4 +1,13 @@
 ﻿Public Class largeUI
+    
+    Protected Overrides ReadOnly Property CreateParams As CreateParams
+        Get
+            Dim newParams = MyBase.CreateParams
+            newParams.ExStyle = newParams.ExStyle Or &H8000000 'WS_EX_NOACTIVATE
+            Return newParams
+        End Get
+    End Property
+
     Private Sub largeUI_FormClosed(sender As Object, e As FormClosedEventArgs) Handles MyBase.FormClosed
         'Close Form1 to terminate the program
         Form1.Close()
@@ -37,86 +46,103 @@
         If Form1.isSelecting Then
             'for selecting Mode only
             loadInterface("e")
-            setAssoCharMode(False)
-            ShowAllLabels()
+            HideSmallLabels()
             Return
         End If
 
         If (charcode.Length = 0 And Form1.lastusedword = "") Then
             'Home page with lastusedword - display associate  char
             loadInterface("s")
-            setAssoCharMode(False)
-            HideAllLabels()
+            HideSmallLabels()
+            HideLargeLabels()
             Return
         End If
 
         If (charcode.Length = 0 And Form1.lastusedword <> "") Then
             'Home page with no lastusedword
             loadInterface("c")
-            setAssoCharMode(True)
-            ShowAllLabels()
+            HideLargeLabels()
+            ShowSmallLabels()
             Return
         End If
 
         If (charcode.Length = 1) Then
             loadInterface(charcode)
-            HideAllLabels()
+            HideSmallLabels()
+            HideLargeLabels()
             Return
         End If
 
         If (charcode.Length = 2) Then
-            setAssoCharMode(False)
             'Char with two parts
             loadInterface("n")
-            HideAllLabels()
+            HideSmallLabels()
+            HideLargeLabels()
         End If
 
         'no need for charcode.Length = 3 because if charcode.Length = 3 , it will in selecting mode
     End Sub
-    Private Sub loadTextFromMiniUI()
-        l1.Text = Form1.Label7.Text
-        l2.Text = Form1.Label8.Text
-        l3.Text = Form1.Label9.Text
-        l4.Text = Form1.Label4.Text
-        l5.Text = Form1.Label5.Text
-        l6.Text = Form1.Label6.Text
-        l7.Text = Form1.Label1.Text
-        l8.Text = Form1.Label2.Text
-        l9.Text = Form1.Label3.Text
+    
+    Private Sub HideLargeLabels()
+        l1.Text = ""
+        l2.Text = ""
+        l3.Text = ""
+        l4.Text = ""
+        l5.Text = ""
+        l6.Text = ""
+        l7.Text = ""
+        l8.Text = ""
+        l9.Text = ""
     End Sub
-
-    Private Sub HideAllLabels()
-        l1.Visible = False
-        l2.Visible = False
-        l3.Visible = False
-        l4.Visible = False
-        l5.Visible = False
-        l6.Visible = False
-        l7.Visible = False
-        l8.Visible = False
-        l9.Visible = False
-
+    Private Sub HideSmallLabels()
+        s1.Visible = False
+        s2.Visible = False
+        s3.Visible = False
+        s4.Visible = False
+        s5.Visible = False
+        s6.Visible = False
+        s7.Visible = False
+        s8.Visible = False
+        s9.Visible = False
     End Sub
-
-    Private Sub ShowAllLabels()
-        l1.Visible = True
-        l2.Visible = True
-        l3.Visible = True
-        l4.Visible = True
-        l5.Visible = True
-        l6.Visible = True
-        l7.Visible = True
-        l8.Visible = True
-        l9.Visible = True
-
+    Private Sub ShowSmallLabels()
+        s1.Visible = True
+        s2.Visible = True
+        s3.Visible = True
+        s4.Visible = True
+        s5.Visible = True
+        s6.Visible = True
+        s7.Visible = True
+        s8.Visible = True
+        s9.Visible = True
     End Sub
+    
     Private Sub loadInterface(key As String)
         Dim path As String = IO.Path.GetTempPath.ToString & "cyinput\lui\"
         PictureBox2.BackgroundImage = System.Drawing.Bitmap.FromFile(path & "cyi_" & key & ".png")
     End Sub
 
     Private Sub largeUI_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        HideAllLabels()
+        HideLargeLabels()
+        HideSmallLabels()
+        s1.Location = PictureBox2.PointToClient(Me.PointToScreen(s1.Location))
+        s1.Parent = PictureBox2
+        s2.Location = PictureBox2.PointToClient(Me.PointToScreen(s2.Location))
+        s2.Parent = PictureBox2
+        s3.Location = PictureBox2.PointToClient(Me.PointToScreen(s3.Location))
+        s3.Parent = PictureBox2
+        s4.Location = PictureBox2.PointToClient(Me.PointToScreen(s4.Location))
+        s4.Parent = PictureBox2
+        s5.Location = PictureBox2.PointToClient(Me.PointToScreen(s5.Location))
+        s5.Parent = PictureBox2
+        s6.Location = PictureBox2.PointToClient(Me.PointToScreen(s6.Location))
+        s6.Parent = PictureBox2
+        s7.Location = PictureBox2.PointToClient(Me.PointToScreen(s7.Location))
+        s7.Parent = PictureBox2
+        s8.Location = PictureBox2.PointToClient(Me.PointToScreen(s8.Location))
+        s8.Parent = PictureBox2
+        s9.Location = PictureBox2.PointToClient(Me.PointToScreen(s9.Location))
+        s9.Parent = PictureBox2
         l1.Location = PictureBox2.PointToClient(Me.PointToScreen(l1.Location))
         l1.Parent = PictureBox2
         l2.Location = PictureBox2.PointToClient(Me.PointToScreen(l2.Location))
@@ -135,7 +161,10 @@
         l8.Parent = PictureBox2
         l9.Location = PictureBox2.PointToClient(Me.PointToScreen(l9.Location))
         l9.Parent = PictureBox2
-
+        l10.Location = PictureBox2.PointToClient(Me.PointToScreen(l10.Location))
+        l10.Parent = PictureBox2
+        l11.Location = PictureBox2.PointToClient(Me.PointToScreen(l11.Location))
+        l11.Parent = PictureBox2
 
         If My.Computer.Info.OSVersion = "6.2.9200.0" And My.Computer.Info.OSFullName.Contains("Windows 8.1") Then
             'Unknown reason caused all items to shift left on this version of Windows 8.1. Fixing it with exceptional patches
@@ -169,87 +198,7 @@
         l8.Left += x
         l9.Left += x
     End Sub
-
-    Dim assoCharSize = False
-    Private Sub setAssoCharMode(mode As Boolean)
-        If (mode = assoCharSize) Then
-            'Already in this mode. Need not to set again.
-            Return
-        End If
-        If (mode = False) Then
-            Dim labelsize As Single = 21.75
-            l1.Size = New Size(43, 43)
-            l1.Font = New Font("MingLiU_HKSCS", labelsize, FontStyle.Bold)
-            shiftDownCorner(l1)
-            l2.Size = New Size(43, 43)
-            l2.Font = New Font("MingLiU_HKSCS", labelsize, FontStyle.Bold)
-            shiftDownCorner(l2)
-            l3.Size = New Size(43, 43)
-            l3.Font = New Font("MingLiU_HKSCS", labelsize, FontStyle.Bold)
-            shiftDownCorner(l3)
-            l4.Size = New Size(43, 43)
-            l4.Font = New Font("MingLiU_HKSCS", labelsize, FontStyle.Bold)
-            shiftDownCorner(l4)
-            l5.Size = New Size(43, 43)
-            l5.Font = New Font("MingLiU_HKSCS", labelsize, FontStyle.Bold)
-            shiftDownCorner(l5)
-            l6.Size = New Size(43, 43)
-            l6.Font = New Font("MingLiU_HKSCS", labelsize, FontStyle.Bold)
-            shiftDownCorner(l6)
-            l7.Size = New Size(43, 43)
-            l7.Font = New Font("MingLiU_HKSCS", labelsize, FontStyle.Bold)
-            shiftDownCorner(l7)
-            l8.Size = New Size(43, 43)
-            l8.Font = New Font("MingLiU_HKSCS", labelsize, FontStyle.Bold)
-            shiftDownCorner(l8)
-            l9.Size = New Size(43, 43)
-            l9.Font = New Font("MingLiU_HKSCS", labelsize, FontStyle.Bold)
-            shiftDownCorner(l9)
-            assoCharSize = False
-        Else
-            Dim labelsize As Integer = 18
-            Dim labelWidth As Integer = 28
-            l1.Size = New Size(labelWidth, labelWidth)
-            l1.Font = New Font("MingLiU_HKSCS", labelsize)
-            shiftUpCorner(l1)
-            l2.Size = New Size(labelWidth, labelWidth)
-            l2.Font = New Font("MingLiU_HKSCS", labelsize)
-            shiftUpCorner(l2)
-            l3.Size = New Size(labelWidth, labelWidth)
-            l3.Font = New Font("MingLiU_HKSCS", labelsize)
-            shiftUpCorner(l3)
-            l4.Size = New Size(labelWidth, labelWidth)
-            l4.Font = New Font("MingLiU_HKSCS", labelsize)
-            shiftUpCorner(l4)
-            l5.Size = New Size(labelWidth, labelWidth)
-            l5.Font = New Font("MingLiU_HKSCS", labelsize)
-            shiftUpCorner(l5)
-            l6.Size = New Size(labelWidth, labelWidth)
-            l6.Font = New Font("MingLiU_HKSCS", labelsize)
-            shiftUpCorner(l6)
-            l7.Size = New Size(labelWidth, labelWidth)
-            l7.Font = New Font("MingLiU_HKSCS", labelsize)
-            shiftUpCorner(l7)
-            l8.Size = New Size(labelWidth, labelWidth)
-            l8.Font = New Font("MingLiU_HKSCS", labelsize)
-            shiftUpCorner(l8)
-            l9.Size = New Size(labelWidth, labelWidth)
-            l9.Font = New Font("MingLiU_HKSCS", labelsize)
-            shiftUpCorner(l9)
-            assoCharSize = True
-        End If
-    End Sub
-
-    Private Sub shiftUpCorner(label As Object)
-        label.top -= 3
-        label.left -= 3
-    End Sub
-
-    Private Sub shiftDownCorner(label As Object)
-        label.top += 3
-        label.left += 3
-    End Sub
-
+    
     Private Sub Panel1_MouseClick(sender As Object, e As MouseEventArgs) Handles Panel1.MouseClick
 
     End Sub
@@ -258,11 +207,52 @@
 
     End Sub
 
-    Private Sub l1_MouseDown(sender As Object, e As MouseEventArgs) Handles l1.MouseDown, l2.MouseDown, l3.MouseDown, l4.MouseDown, l5.MouseDown, l6.MouseDown, l7.MouseDown, l8.MouseDown, l9.MouseDown
+    Private Sub l_MouseDown(sender As Object, e As MouseEventArgs) Handles l1.MouseDown, l2.MouseDown, l3.MouseDown, l4.MouseDown, l5.MouseDown, l6.MouseDown, l7.MouseDown, l8.MouseDown, l9.MouseDown
+        If e.Button = MouseButtons.Left Then
+            Select Case sender.Tag
+                Case "1"
+                    Form1.HandleHotkey(97)
+                Case "2"
+                    Form1.HandleHotkey(98)
+                Case "3"
+                    Form1.HandleHotkey(99)
+                Case "4"
+                    Form1.HandleHotkey(100)
+                Case "5"
+                    Form1.HandleHotkey(101)
+                Case "6"
+                    Form1.HandleHotkey(102)
+                Case "7"
+                    Form1.HandleHotkey(103)
+                Case "8"
+                    Form1.HandleHotkey(104)
+                Case "9"
+                    Form1.HandleHotkey(105)
+            End Select
+        End If
         If e.Button = MouseButtons.Right And Form1.isSelecting = True Then
             Dim labelString As String = sender.Text.ToString.Trim
             Form1.enterHomophonicMode(labelString)
         End If
     End Sub
 
+        Private Sub l10_MouseDown(sender As Object, e As MouseEventArgs) Handles l10.MouseDown
+        If e.Button = MouseButtons.Left Then
+            Form1.HandleHotkey(96)
+        End If
+    End Sub
+
+    Private Sub l11_MouseDown(sender As Object, e As MouseEventArgs) Handles l11.MouseDown
+        If e.Button = MouseButtons.Left Then
+            Form1.HandleHotkey(110)
+        End If
+    End Sub
+
+    Private Sub s_MouseDown(sender As Object, e As MouseEventArgs) Handles s1.MouseDown, s2.MouseDown, s3.MouseDown, s4.MouseDown, s5.MouseDown, s6.MouseDown, s7.MouseDown, s8.MouseDown, s9.MouseDown
+        If e.Button = MouseButtons.Left Then
+            Dim labelString As String = sender.Text.ToString.Trim
+            Form1.SendAssoWord(labelString)
+        End If
+    End Sub
+    
 End Class


### PR DESCRIPTION
#30 
I added WS_EX_NOACTIVATE to Form.CreateParams,
which disable window from getting keyboard focus,
and made both large buttons and small 關聯字 clickable.
I tested it on windows 10.

ps1. i have no idea how ApplyWin8ThemeBugPatch works, please fix it later.
ps2. i suggest setting 直接輸出 as default.